### PR TITLE
Handles delayed capture for a PaymentIntent

### DIFF
--- a/db/migrate/20191206144712_add_columns_to_charges.rb
+++ b/db/migrate/20191206144712_add_columns_to_charges.rb
@@ -1,0 +1,6 @@
+class AddColumnsToCharges < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pay_charges, :payment_intent, :string
+    add_column :pay_charges, :captured, :boolean
+  end
+end

--- a/lib/pay/payment.rb
+++ b/lib/pay/payment.rb
@@ -41,6 +41,10 @@ module Pay
       intent.is_a?(::Stripe::SetupIntent)
     end
 
+    def capture
+      intent.capture
+    end
+
     def validate
       if requires_payment_method?
         raise Pay::InvalidPaymentMethod.new(self)

--- a/lib/pay/stripe/charge.rb
+++ b/lib/pay/stripe/charge.rb
@@ -8,8 +8,24 @@ module Pay
         processor == "stripe"
       end
 
+      # Doesn't work in jumpstartpro
+      # #######
+      # Team.first.charges.first.stripe_charge
+      # > NoMethodError: undefined method `retrieve' for Pay::Stripe::Charge:Module
       def stripe_charge
         Stripe::Charge.retrieve(processor_id)
+      rescue ::Stripe::StripeError => e
+        raise Error, e.message
+      end
+
+      # To capture a Charge created through a PaymentIntent we have to capture the PaymentIntent itself.
+      # #######
+      # Stripe::Charge.retrieve(processor_id).capture
+      # > Stripe::InvalidRequestError: This uncaptured Charge was created by a PaymentIntent. You must capture the PaymentIntent instead.
+      def stripe_capture
+        Pay::Payment.from_id(payment_intent).capture
+        update(captured: true)
+
       rescue ::Stripe::StripeError => e
         raise Error, e.message
       end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_16_015720) do
+ActiveRecord::Schema.define(version: 2019_12_06_144712) do
 
   create_table "pay_charges", force: :cascade do |t|
     t.integer "owner_id"
@@ -24,6 +24,8 @@ ActiveRecord::Schema.define(version: 2019_08_16_015720) do
     t.string "card_exp_year"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "payment_intent"
+    t.boolean "captured"
     t.index ["owner_id"], name: "index_pay_charges_on_owner_id"
   end
 


### PR DESCRIPTION
Add `payment_intent` and `captured` columns in Pay Charge to easily deal with delayed capture (PaymentIntent that "requires_capture") and interact more easily with a related Stripe::PaymentIntent.

The same thing could be done to handle PaymentIntent that `requires_confirmation`

However a charge not captured shouldn't `notify_user`